### PR TITLE
Dev: Make test runnable out of the box, without having to update them

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -3,6 +3,10 @@
 #        - should be a single line, even for defining multiple clients
 #        - leave empty if Azure AD auth against Azure OpenAI is used.
 clients:
+  # Default key used for project tests, localed in "test/test_*.py" files
+  - name: Built-in tests
+    key: 123abc
+  # Usage examples
   - name: Team 1
     key: 28ef59ae30342978f81c4ad96ce47ab
   - name: Team 2

--- a/test/test_functions.py
+++ b/test/test_functions.py
@@ -7,10 +7,10 @@ import openai
 openai.api_type = "azure"
 openai.api_base = "http://localhost"
 openai.api_version = "2023-07-01-preview"
-openai.api_key = "98ef51ae30342978f81c4ad96ce47ab"
+openai.api_key = "123abc"
 
 response = openai.ChatCompletion.create(
-    engine="gpt-35-turbo-0613",
+    engine="gpt",
     messages=[
         {
             "role": "user",

--- a/test/test_langchain.py
+++ b/test/test_langchain.py
@@ -6,8 +6,8 @@ from langchain.agents import AgentType, initialize_agent, tool
 from langchain.llms import AzureOpenAI
 
 OPENAI_API_BASE = "http://localhost"
-OPENAI_API_KEY = "0123456789abcdef0123456789abcde"
-OPENAI_API_DEPLOYMENT_NAME = "gpt-35-turbo"
+OPENAI_API_KEY = "123abc"
+OPENAI_API_DEPLOYMENT_NAME = "gpt"
 OPENAI_API_VERSION = "2023-03-15-preview"
 
 

--- a/test/test_onetime.py
+++ b/test/test_onetime.py
@@ -5,10 +5,10 @@ import openai
 openai.api_type = "azure"
 openai.api_base = "http://localhost"
 openai.api_version = "2023-03-15-preview"
-openai.api_key = "98ef51ae30342978f81c4ad96ce47ab"
+openai.api_key = "123abc"
 
 response = openai.ChatCompletion.create(
-    engine="gpt-35-turbo",
+    engine="gpt",
     messages=[
         {
             "role": "system",

--- a/test/test_streaming.http
+++ b/test/test_streaming.http
@@ -1,6 +1,6 @@
 ### against real AOAI
 
-POST https://___.openai.azure.com/openai/deployments/gpt-35-turbo/chat/completions?api-version=2023-03-15-preview HTTP/1.1
+POST https://___.openai.azure.com/openai/deployments/gpt/chat/completions?api-version=2023-03-15-preview HTTP/1.1
 Content-Type: application/json
 Connection: keep-alive
 api-key: ___
@@ -13,7 +13,7 @@ Accept: */*
 
 ### against local PowerProxy
 
-POST http://localhost/openai/deployments/gpt-35-turbo/chat/completions?api-version=2023-03-15-preview HTTP/1.1
+POST http://localhost/openai/deployments/gpt/chat/completions?api-version=2023-03-15-preview HTTP/1.1
 Content-Type: application/json
 Connection: keep-alive
 api-key: 98ef51ae30342978f81c4ad96ce47ab
@@ -26,7 +26,7 @@ Accept: */*
 
 ### against PowerProxy deployed on Container Apps
 
-POST https://___.___.___.azurecontainerapps.io/openai/deployments/gpt-35-turbo/chat/completions?api-version=2023-03-15-preview HTTP/1.1
+POST https://___.___.___.azurecontainerapps.io/openai/deployments/gpt/chat/completions?api-version=2023-03-15-preview HTTP/1.1
 Content-Type: application/json
 Connection: keep-alive
 api-key: 98ef51ae30342978f81c4ad96ce47ab

--- a/test/test_streaming.py
+++ b/test/test_streaming.py
@@ -5,10 +5,10 @@ import openai
 openai.api_type = "azure"
 openai.api_base = "http://localhost"
 openai.api_version = "2023-03-15-preview"
-openai.api_key = "98ef51ae30342978f81c4ad96ce47ab"
+openai.api_key = "123abc"
 
 response = openai.ChatCompletion.create(
-    engine="gpt-35-turbo",
+    engine="gpt",
     messages=[
         {
             "role": "system",

--- a/test/test_streaming_functions.py
+++ b/test/test_streaming_functions.py
@@ -7,10 +7,10 @@ import openai
 openai.api_type = "azure"
 openai.api_base = "http://localhost"
 openai.api_version = "2023-07-01-preview"
-openai.api_key = "98ef51ae30342978f81c4ad96ce47ab"
+openai.api_key = "123abc"
 
 response = openai.ChatCompletion.create(
-    engine="gpt-35-turbo-0613",
+    engine="gpt",
     messages=[
         {
             "role": "user",


### PR DESCRIPTION
Unify both deployment name and API key. This API key is also pre-written in the example config. As this, user can run test out-of-the-box, without having to update the test files manually.
