### PR TITLE
Update powerproxy.py: httpx client default timeout is only 5 sec, bump to 120 sec to get non-streaming responses taking longer through

### DIFF
--- a/app/powerproxy.py
+++ b/app/powerproxy.py
@@ -229,6 +229,7 @@ async def handle_request(request: Request, path: str):
         aoai_response = await aoai_endpoint["client"].request(
             request.method,
             path,
+            timeout=120.0,
             params=request.query_params,
             headers=headers,
             content=routing_slip["incoming_request_body"],


### PR DESCRIPTION
120 sec timeout chosen as used elsewhere throughout the application