### PR TITLE
fix: remove content-length if transfer-encoding is present

### DIFF
--- a/app/powerproxy.py
+++ b/app/powerproxy.py
@@ -298,11 +298,14 @@ async def handle_request(request: Request, path: str):
             except:
                 # eat any exception in case the response cannot be parsed
                 pass
-            return Response(
+            response = Response(
                 content=body,
                 status_code=aoai_response.status_code,
                 headers=routing_slip["response_headers_from_target"],
             )
+            if "Transfer-Encoding" in response.headers and "Content-Length" in response.headers:
+                del response.headers["Content-Length"]
+            return response
         case True:
             # event stream
             # forward and process events as they come in


### PR DESCRIPTION
- fix #53, as FastAPI Response adds content-length in this case, which is forbidden by RFC